### PR TITLE
dev/middleware.tsは自branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/middleware.ts merge=ours


### PR DESCRIPTION
さくらのVPSで使うmiddlewareと開発中に使うmiddlewareが違うため、自ブランチのmiddlewareを優先してマージしないようにした。