### PR TITLE
Fix/input support

### DIFF
--- a/src/app/teacher/createTest/page.tsx
+++ b/src/app/teacher/createTest/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { Suspense, useEffect, useState, useRef } from "react";
 import {
+  Autocomplete,
   Alert,
   Box,
   Button,
@@ -37,6 +38,8 @@ import SaveIcon from "@mui/icons-material/Save";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import ImageIcon from "@mui/icons-material/Image";
 import CodeIcon from "@mui/icons-material/Code";
+import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 
 import {
   TestFrame,
@@ -50,7 +53,6 @@ import { Test, Section, Question, Class } from "@prisma/client";
 import dayjs, { Dayjs } from "dayjs";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import Autocomplete from '@mui/material/Autocomplete';
 
 import Latex from "react-latex-next";
 import { useRouter, useSearchParams } from "next/navigation"
@@ -82,6 +84,8 @@ function ClientSearchParamWrapper() {
   const [currentTestId, setCurrentTestId] = useState<number | null>(param_testId ? Number(param_testId) : null);
 
   const initialSectionsRef = useRef<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null); 
+  
 
   const getInitialStartDate = () => {
     const now = dayjs();
@@ -101,6 +105,47 @@ function ClientSearchParamWrapper() {
 
   const [sectionContextMenu, setSectionContextMenu] = useState<{ mouseX: number; mouseY: number; index: number } | null>(null);
   const [draggedSectionIndex, setDraggedSectionIndex] = useState<number | null>(null);
+
+  const exportToJson = () => {
+    const exportData = {
+      title: testTitle,
+      summary: testSummary,
+      maxResubmissions: maxResubmissions,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      sections: sections,
+    };
+
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${testTitle || "test_data"}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importFromJson = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target?.result as string);
+        setTestTitle(data.title || "");
+        setTestSummary(data.summary || "");
+        setMaxResubmissions(data.maxResubmissions || 0);
+        if (data.startDate) setStartDate(dayjs(data.startDate));
+        if (data.endDate) setEndDate(dayjs(data.endDate));
+        if (data.sections) setSections(data.sections);
+      } catch (err) {
+        alert(msg.ERROR_FILE_LOAD);
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  };
 
   const handleSectionContextMenu = (event: React.MouseEvent, index: number) => {
     event.preventDefault();
@@ -297,6 +342,29 @@ function ClientSearchParamWrapper() {
         </Stack>
 
         <Stack direction="row" spacing={2} alignItems="center">
+          {/* JSON読み込み用隠しインプット */}
+          <input
+            type="file"
+            accept="application/json"
+            style={{ display: "none" }}
+            ref={fileInputRef}
+            onChange={importFromJson}
+          />
+          <Button
+            variant="outlined"
+            startIcon={<FolderOpenIcon />}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {msg.OPEN_JSON}
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<FileDownloadIcon />}
+            onClick={exportToJson}
+          >
+            {msg.SAVE_JSON}
+          </Button>
+          
           <Button
             variant="contained"
             size="large"
@@ -320,6 +388,8 @@ function ClientSearchParamWrapper() {
           />
         </Stack>
       </Stack>
+      
+      {/* 以下のコンテンツ部分は変更なし */}
       <Box sx={{ flexGrow: 1, minHeight: 0, p: 1.5, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
         <Paper elevation={3} sx={{ flexGrow: 1, minHeight: 0, display: 'flex', overflow: 'hidden', borderRadius: 2 }}>
           <Box sx={{ width: '200px', flexShrink: 0, borderRight: 1, borderColor: "divider", bgcolor: 'grey.50', overflowY: 'auto', height: '100%' }}>
@@ -600,9 +670,6 @@ const SectionPage = ({ index, section, setSection, deleteSection }: any) => {
     setSection({ section: newS, questions: section.questions });
   }
 
-  // =========================================================================
-  // ★ エラーの原因：この部分が handleSectionSummaryChange の中に入っていました
-  // =========================================================================
   const [questionContextMenu, setQuestionContextMenu] = useState<{ mouseX: number; mouseY: number; index: number } | null>(null);
   const [draggedQuestionIndex, setDraggedQuestionIndex] = useState<number | null>(null);
 

--- a/src/app/teacher/grading/[testid]/page.tsx
+++ b/src/app/teacher/grading/[testid]/page.tsx
@@ -12,7 +12,9 @@ import { setAnswerPoints } from "@/app/api/test/setAnswerPoints";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from '@clerk/nextjs';
 import { TeacherGuard } from "@/lib/guard";
+import judge from "@/lib/judge";
 import { msg } from "@/msg-ja";
+
 
 import styles from "./styles.module.css";
 
@@ -170,6 +172,40 @@ export default function GradingPage({ params }: { params: Promise<{ testid: numb
 
   const [texDialogOpen, setTexDialogOpen] = useState(false);
   const [currentTexContent, setCurrentTexContent] = useState("");
+  const [autoGradingDialogOpen, setAutoGradingDialogOpen] = useState(false);
+
+  const autoGradingHandle = useCallback(() => {
+    if (!Test_ || !submissionData) return;
+
+    setPoints(prevPoints => {
+      const newPoints = { ...prevPoints };
+      const allQuestions = Test_.sections.flatMap((s: any) => s.questions);
+
+      submissionData.forEach((submission, dataIndex) => {
+        const studentPoints = { ...newPoints[dataIndex] };
+
+        submission.answers.forEach((answer: Answer, qIndex: number) => {
+          const question = allQuestions[qIndex];
+          if (!question) return;
+
+          if (answer.text.trim() === "") {
+            studentPoints[qIndex] = 0;
+          } else {
+            const result = judge(question.answer, answer.text);
+            if (result === 1 || result === 2) {
+              studentPoints[qIndex] = question.allocationPoint ?? 1;
+            } else {
+              studentPoints[qIndex] = -1;
+            }
+          }
+        });
+        newPoints[dataIndex] = studentPoints;
+      });
+      return newPoints;
+    });
+
+    setAutoGradingDialogOpen(false);
+  }, [Test_, submissionData]);
 
   const handleOpenTexDialog = useCallback((tex: string, event: React.MouseEvent) => {
     event.preventDefault();
@@ -410,19 +446,19 @@ export default function GradingPage({ params }: { params: Promise<{ testid: numb
     const totalQuestionsCount = Test_.sections.reduce((acc: number, section: any) => acc + section.questions.length, 0);
     const currentClass = Test_.classes.at(classIndex);
 
-if (currentClassUsers.length > 0) {
+    if (currentClassUsers.length > 0) {
       currentClassUsers.forEach(({ user, originalIndex }: { user: User; originalIndex: number }) => {
         let rn: string = "";
         const data_index = submission_index[originalIndex];
         const submission = data_index !== undefined ? submissionData[data_index] : null;
 
-        let statusText = msg.NOT_SUBMITTED; 
+        let statusText = msg.NOT_SUBMITTED;
         if (submission && Test_.endDate) {
           const subDate = new Date(submission.submissionDate);
           const endDate = new Date(Test_.endDate);
           statusText = subDate > endDate ? msg.OVERDUE : msg.ON_TIME;
         } else if (submission) {
-          statusText = msg.SUBMITTED; 
+          statusText = msg.SUBMITTED;
         }
 
         const metrics = userMetrics[originalIndex] || { totalPoints: 0, ungradedCount: 0 };
@@ -475,7 +511,7 @@ if (currentClassUsers.length > 0) {
 
 
 
-const renderSubmissionStatus = useCallback((user_index: number) => {
+  const renderSubmissionStatus = useCallback((user_index: number) => {
     const data_index = submission_index[user_index];
     const submission = data_index !== undefined && submissionData ? submissionData[data_index] : null;
 
@@ -536,26 +572,38 @@ const renderSubmissionStatus = useCallback((user_index: number) => {
               </Typography>
             </Box>
 
-            <Box width="10em">
-              <Box display="flex" justifyContent="right">
-                {Test_?.classes?.length > 0 &&
-                  <TextField select id="select_class" value={classId || ''} onChange={selectClassHandle} fullWidth>
-                    {
-                      Test_?.classes.map((a_class: Class) =>
-                        <MenuItem key={"select_class_" + a_class.id} value={a_class.id}>
-                          {a_class.name}
-                        </MenuItem>
-                      )
-                    }
-                  </TextField>
-                }
+            <Box display="flex" alignItems="flex-start" gap={1}>
+              {/* 自動採点ボタン */}
+              <Button
+                variant="outlined"
+                color="primary"
+                onClick={() => setAutoGradingDialogOpen(true)}
+                sx={{ height: '56px', whiteSpace: 'nowrap' }} // TextField(select)の高さに合わせる
+              >
+                {msg.AUTO_GRADING}
+              </Button>
+
+              <Box width="10em">
+                <Box display="flex" justifyContent="right">
+                  {Test_?.classes?.length > 0 &&
+                    <TextField select id="select_class" value={classId || ''} onChange={selectClassHandle} fullWidth>
+                      {
+                        Test_?.classes.map((a_class: Class) =>
+                          <MenuItem key={"select_class_" + a_class.id} value={a_class.id}>
+                            {a_class.name}
+                          </MenuItem>
+                        )
+                      }
+                    </TextField>
+                  }
+                </Box>
+                <Typography textAlign="right">
+                  {msg.CLASS_ID}: {classId ?? '...'}
+                </Typography>
+                <Typography textAlign="right">
+                  {msg.TEST_ID}: {testid}
+                </Typography>
               </Box>
-              <Typography textAlign="right">
-                {msg.CLASS_ID}: {classId ?? '...'}
-              </Typography>
-              <Typography textAlign="right">
-                {msg.TEST_ID}: {testid}
-              </Typography>
             </Box>
           </Box>
         </Box>
@@ -677,6 +725,19 @@ const renderSubmissionStatus = useCallback((user_index: number) => {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseTexDialog}>{msg.CLOSE}</Button>
+        </DialogActions>
+      </Dialog>
+      {/* 自動採点確認ダイアログ */}
+      <Dialog open={autoGradingDialogOpen} onClose={() => setAutoGradingDialogOpen(false)}>
+        <DialogTitle>{msg.AUTO_GRADING_CONFIRM_TITLE}</DialogTitle>
+        <DialogContent>
+          <Typography>{msg.AUTO_GRADING_CONFIRM_MESSAGE}</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAutoGradingDialogOpen(false)}>{msg.CANCEL}</Button>
+          <Button onClick={autoGradingHandle} color="primary" variant="contained">
+            {msg.EXECUTE}
+          </Button>
         </DialogActions>
       </Dialog>
     </TeacherGuard>

--- a/src/app/teacher/grading/[testid]/page.tsx
+++ b/src/app/teacher/grading/[testid]/page.tsx
@@ -12,7 +12,7 @@ import { setAnswerPoints } from "@/app/api/test/setAnswerPoints";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from '@clerk/nextjs';
 import { TeacherGuard } from "@/lib/guard";
-import judge from "@/lib/judge";
+import judge, { format } from "@/lib/judge";
 import { msg } from "@/msg-ja";
 
 
@@ -720,6 +720,16 @@ export default function GradingPage({ params }: { params: Promise<{ testid: numb
           <Box sx={{ p: 2, bgcolor: 'grey.100', borderRadius: 1, overflowX: 'auto' }}>
             <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordWrap: 'break-word', fontFamily: 'monospace' }}>
               {currentTexContent}
+            </pre>
+          </Box>
+        </DialogContent>
+        <DialogContent>
+          <Typography variant="caption" color="text.secondary" gutterBottom display="block">
+            {msg.FORMATED_TEX}
+          </Typography>
+          <Box sx={{ p: 2, bgcolor: 'blue.50', borderRadius: 1, overflowX: 'auto', border: '1px solid', borderColor: 'blue.100' }}>
+            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordWrap: 'break-word', fontFamily: 'monospace' }}>
+              {format(currentTexContent)}
             </pre>
           </Box>
         </DialogContent>

--- a/src/compornents/Question.tsx
+++ b/src/compornents/Question.tsx
@@ -30,6 +30,8 @@ export default function Question({ id, number, question, answer, insertType, ins
   const [cur, setCur] = React.useState(true);
   const [isFirstRender, setIsFirstRender] = React.useState(true);
 
+  const [showKeyboard, setShowKeyboard] = React.useState(false);
+
   useEffect(() => {
     if (isFirstRender) {
       setIsFirstRender(false);
@@ -89,6 +91,16 @@ export default function Question({ id, number, question, answer, insertType, ins
     }
   }
 
+  const handleFocus = () => {
+    setShowKeyboard(true);
+  };
+
+  const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setShowKeyboard(false);
+    }
+  };
+
   return (
 
     <Stack spacing={0}>
@@ -110,160 +122,166 @@ export default function Question({ id, number, question, answer, insertType, ins
         </IconButton>
       </Box>
 
-      <TextField
-        placeholder="Answer"
-        hiddenLabel
-        fullWidth
-        size="small"
-        variant="filled"
-        multiline
-        spellCheck="false"
-        value={answer}
-        inputProps={{ style: { fontFamily: "monospace", fontSize: 17 } }}
-        inputRef={inputRef}
-        onChange={(e) => {
-          changeAnswer(e.target.value)
-          updateSelection()
-        }}
-        onSelect={() => {
-          updateSelection()
-        }}
-        onClick={() => {
-          updateSelection()
-        }}
-        onTouchEnd={() => {
-          updateSelection()
-        }}
-      />
+      <Box onFocus={handleFocus} onBlur={handleBlur}>
+        <TextField
+          placeholder="Answer"
+          hiddenLabel
+          fullWidth
+          size="small"
+          variant="filled"
+          multiline
+          spellCheck="false"
+          value={answer}
+          inputProps={{ style: { fontFamily: "monospace", fontSize: 17 } }}
+          inputRef={inputRef}
+          onChange={(e) => {
+            changeAnswer(e.target.value)
+            updateSelection()
+          }}
+          onSelect={() => {
+            updateSelection()
+          }}
+          onClick={() => {
+            updateSelection()
+          }}
+          onTouchEnd={() => {
+            updateSelection()
+          }}
+        />
 
-      <Box sx={{ paddingTop: 0.5, paddingBottom: 0.5, width: "100%" }}>
-        <Box display="flex" justifyContent="space-between" width="100%">
-          <IconButton aria-label="move left" onClick={
-            () => {
-              if (selectionStart != selectionEnd) {
-                setSelectionStart(selectionStart);
-                setSelectionEnd(selectionStart);
-              } else if (selectionStart == 0) {
-              } else {
-                setSelectionStart(selectionStart - 1);
-                setSelectionEnd(selectionStart - 1);
-              }
-              setCur(!cur);
-            }}>
-            <ArrowBack />
-          </IconButton>
-          <Box display="flex">
-            <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => { insertCommand("\\") }}>
-              \
-            </Button>
-            <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand("{}", 1, 1)}>
-              {"{ }"}
-            </Button>
-            <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand("()", 1, 1)}>
-              {"( )"}
-            </Button>
-            <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand(",")}>
-              {","}
-            </Button>
-          </Box>
-          <IconButton aria-label="move right" onClick={
-            () => {
-              if (selectionStart != selectionEnd) {
-                setSelectionStart(selectionEnd);
-                setSelectionEnd(selectionEnd);
-              } else if (selectionStart == answer.length) {
-              } else {
-                setSelectionStart(selectionStart + 1);
-                setSelectionEnd(selectionStart + 1);
-              }
-              setCur(!cur);
-            }}>
-            <ArrowForward />
-          </IconButton>
-        </Box>
-      </Box>
-      <Box sx={{ overflowX: "scroll" }}>
-        <Box sx={{ display: 'flex', paddingBottom: 1.5 }}>
-          <Box display="flex">
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("+")}>
-                <InlineMath math="+"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("=")}>
-                <InlineMath math="="></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\geqq")}>
-                <InlineMath math="\geqq"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\leqq")}>
-                <InlineMath math="\leqq"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("-")}>
-                <InlineMath math="-"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\times")}>
-                <InlineMath math="\times"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\pm ")}>
-                <InlineMath math="\pm"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\pi")}>
-                <InlineMath math="\pi"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\frac{a}{b}", 6, 7)}>
-                <InlineMath math="\frac{a}{b}"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sqrt{a}", 6, 7)}>
-                <InlineMath math="\sqrt{a}"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\vec{a}", 5, 6)}>
-                <InlineMath math="\vec{a}"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("^{a}", 2, 3)}>
-                <InlineMath math="□^{a}"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\log{a}", 5, 6)}>
-                <InlineMath math="\log{a}"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\log_{a}{b}", 6, 7)}>
-                <InlineMath math="\log_{a}{b}"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sin{a}", 5, 6)}>
-                <InlineMath math="\sin{a}"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\cos{a}", 5, 6)}>
-                <InlineMath math="\cos{a}"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\tan{a}", 5, 6)}>
-                <InlineMath math="\tan{a}"></InlineMath>
-              </Button>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sum_{i=1}^{n}")}>
-                <InlineMath math="\sum_{i=1}^{n}"></InlineMath>
-              </Button>
-            </Stack>
-            <Stack>
-              <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\begin{pmatrix}\n  a & b \\\\\n  c & d\n\\end{pmatrix}", 18, 19)}>
-                <InlineMath math="\begin{pmatrix}a & b \\\\ c & d \end{pmatrix}"></InlineMath>
-              </Button>
-            </Stack>
-          </Box>
-        </Box>
+        {showKeyboard && (
+          <>
+            <Box sx={{ paddingTop: 0.5, paddingBottom: 0.5, width: "100%" }}>
+              <Box display="flex" justifyContent="space-between" width="100%">
+                <IconButton aria-label="move left" onClick={
+                  () => {
+                    if (selectionStart != selectionEnd) {
+                      setSelectionStart(selectionStart);
+                      setSelectionEnd(selectionStart);
+                    } else if (selectionStart == 0) {
+                    } else {
+                      setSelectionStart(selectionStart - 1);
+                      setSelectionEnd(selectionStart - 1);
+                    }
+                    setCur(!cur);
+                  }}>
+                  <ArrowBack />
+                </IconButton>
+                <Box display="flex">
+                  <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => { insertCommand("\\") }}>
+                    \
+                  </Button>
+                  <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand("{}", 1, 1)}>
+                    {"{ }"}
+                  </Button>
+                  <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand("()", 1, 1)}>
+                    {"( )"}
+                  </Button>
+                  <Button variant="outlined" sx={{ textTransform: 'none', width: 10, whiteSpace: 'nowrap' }} onClick={() => insertCommand(",")}>
+                    {","}
+                  </Button>
+                </Box>
+                <IconButton aria-label="move right" onClick={
+                  () => {
+                    if (selectionStart != selectionEnd) {
+                      setSelectionStart(selectionEnd);
+                      setSelectionEnd(selectionEnd);
+                    } else if (selectionStart == answer.length) {
+                    } else {
+                      setSelectionStart(selectionStart + 1);
+                      setSelectionEnd(selectionStart + 1);
+                    }
+                    setCur(!cur);
+                  }}>
+                  <ArrowForward />
+                </IconButton>
+              </Box>
+            </Box>
+            <Box sx={{ overflowX: "scroll" }}>
+              <Box sx={{ display: 'flex', paddingBottom: 1.5 }}>
+                <Box display="flex">
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("+")}>
+                      <InlineMath math="+"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("=")}>
+                      <InlineMath math="="></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\geqq")}>
+                      <InlineMath math="\geqq"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\leqq")}>
+                      <InlineMath math="\leqq"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("-")}>
+                      <InlineMath math="-"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\times")}>
+                      <InlineMath math="\times"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\pm ")}>
+                      <InlineMath math="\pm"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\pi")}>
+                      <InlineMath math="\pi"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\frac{a}{b}", 6, 7)}>
+                      <InlineMath math="\frac{a}{b}"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sqrt{a}", 6, 7)}>
+                      <InlineMath math="\sqrt{a}"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\vec{a}", 5, 6)}>
+                      <InlineMath math="\vec{a}"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("^{a}", 2, 3)}>
+                      <InlineMath math="□^{a}"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\log{a}", 5, 6)}>
+                      <InlineMath math="\log{a}"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\log_{a}{b}", 6, 7)}>
+                      <InlineMath math="\log_{a}{b}"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sin{a}", 5, 6)}>
+                      <InlineMath math="\sin{a}"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\cos{a}", 5, 6)}>
+                      <InlineMath math="\cos{a}"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\tan{a}", 5, 6)}>
+                      <InlineMath math="\tan{a}"></InlineMath>
+                    </Button>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\sum_{i=1}^{n}")}>
+                      <InlineMath math="\sum_{i=1}^{n}"></InlineMath>
+                    </Button>
+                  </Stack>
+                  <Stack>
+                    <Button variant="outlined" sx={{ textTransform: 'none', width: 15, whiteSpace: 'nowrap' }} onClick={() => insertCommand("\\begin{pmatrix}\n  a & b \\\\\n  c & d\n\\end{pmatrix}", 18, 19)}>
+                      <InlineMath math="\begin{pmatrix}a & b \\\\ c & d \end{pmatrix}"></InlineMath>
+                    </Button>
+                  </Stack>
+                </Box>
+              </Box>
+            </Box>
+          </>
+        )}
       </Box>
     </Stack >
 

--- a/src/lib/judge.tsx
+++ b/src/lib/judge.tsx
@@ -2,21 +2,24 @@ import nerdamer from 'nerdamer';
 
 // 判定結果の定義[cite: 3]
 enum JudgeResult {
-  Unknown,
-  MabyCorrect,
-  Correct,
+  Unknown,      // 0: 判定不能または不一致
+  MabyCorrect,  // 1: 数学的に等価
+  Correct,      // 2: 文字列またはフォーマット後の一致
 }
 
+/**
+ * 正解と入力された解答を比較判定するメイン関数[cite: 3, 8]
+ */
 export default function judge(correct_answer_tex: string, your_answer_tex: string) {
   // 文字列の前後空白を削除[cite: 3]
   correct_answer_tex = trimSpace(correct_answer_tex);
   your_answer_tex = trimSpace(your_answer_tex);
 
-  // フォーマット処理の適用
+  // 1. フォーマット処理（表記揺れの吸収）を適用[cite: 8]
   let c_f = format(correct_answer_tex);
   let y_f = format(your_answer_tex);
 
-  // 1. 文字列としての完全一致判定[cite: 8]
+  // 2. 文字列レベルでの一致判定（完全一致またはフォーマット後一致）[cite: 8]
   if (correct_answer_tex === your_answer_tex) {
     console.log("完全一致");
     return JudgeResult.Correct;
@@ -25,9 +28,17 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
     return JudgeResult.Correct;
   }
 
-  // 2. 数学的な等価判定 (Nerdamerを使用)[cite: 3, 8]
+  // 3. すべての空白を削除して一致判定（日本語と数式の境界のスペース等を無視）
+  const c_f_no_space = c_f.replace(/\s/g, '');
+  const y_f_no_space = y_f.replace(/\s/g, '');
+  if (c_f_no_space !== "" && c_f_no_space === y_f_no_space) {
+    console.log("空白をすべて削除すると一致");
+    return JudgeResult.Correct;
+  }
+
+  // 4. 数学的な等価判定 (Nerdamerを使用)[cite: 3, 8]
   try {
-    // $を取り除き、純粋な数式として評価
+    // $マークを削除して純粋な数式としてパース
     let c_n = nerdamer.convertFromLaTeX(correct_answer_tex.replace(/\$/g, ''));
     let y_n = nerdamer.convertFromLaTeX(your_answer_tex.replace(/\$/g, ''));
 
@@ -40,7 +51,7 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
     }
   } catch (e) { }
 
-  // 3. フォーマット後の数式一致判定[cite: 3, 8]
+  // 5. フォーマット済みの文字列で数学的な等価判定[cite: 8]
   try {
     let c_f_n = nerdamer.convertFromLaTeX(c_f.replace(/\$/g, ''));
     let y_f_n = nerdamer.convertFromLaTeX(y_f.replace(/\$/g, ''));
@@ -54,31 +65,39 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
   return JudgeResult.Unknown;
 }
 
-// 先頭と末尾の空白を削除[cite: 3, 8]
+/**
+ * 前後の空白削除[cite: 3]
+ */
 function trimSpace(input: string): string {
   return input.replace(/^\s+|\s+$/g, '');
 }
 
-// 全角文字を半角に、句読点をカンマ・ピリオドに変換
+/**
+ * 全角英数字・記号を半角に変換し、句読点を正規化[cite: 8]
+ */
 function zenkakuToHankaku(str: string): string {
   return str
-    // 英数字の変換[cite: 8]
+    // 全角英数字を半角へ[cite: 8]
     .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0))
-    // 記号・括弧の変換
-    .replace(/[，、]/g, ',') // 全角カンマと読点
-    .replace(/[．。]/g, '.') // 全角ピリオドと句点
-    .replace(/（/g, '(')   // 丸括弧
+    // 全角スペースを半角へ（数式の分断を防ぐ重要処理）[cite: 8]
+    .replace(/　/g, ' ')
+    // 記号・括弧の置換[cite: 8]
+    .replace(/[，、]/g, ',')
+    .replace(/[．。]/g, '.')
+    .replace(/（/g, '(')
     .replace(/）/g, ')')
-    .replace(/［/g, '[')   // 角括弧
+    .replace(/［/g, '[')
     .replace(/］/g, ']')
-    .replace(/｛/g, '{')   // 中括弧
+    .replace(/｛/g, '{')
     .replace(/｝/g, '}');
 }
 
-// 記号やコマンドの標準化
+/**
+ * Unicode記号や特定のTeXコマンドを標準形式に置換[cite: 8]
+ */
 function normalizeTeXCommand(input: string): string {
   return input
-    // コマンドの標準化[cite: 8]
+    // LaTeXコマンドの標準化[cite: 8]
     .replace(/\\dfrac/g, '\\frac')
     .replace(/\\tfrac/g, '\\frac')
     .replace(/\\left/g, '')
@@ -86,33 +105,52 @@ function normalizeTeXCommand(input: string): string {
     .replace(/\\geqq/g, '\\ge')
     .replace(/\\leqq/g, '\\le')
     
-    // Unicode記号をTeXに置換[cite: 8]
-    .replace(/＝/g, '=')
-    .replace(/≠/g, '\\ne')
+    // Unicode数学記号をTeX/標準記号へ置換[cite: 8]
+    .replace(/[＝=]/g, '=')
+    .replace(/[≠]/g, '\\ne')
+    .replace(/[＞>]/g, '>')
+    .replace(/[＜<]/g, '<')
     .replace(/[≧≥]/g, '\\ge')
     .replace(/[≦≤]/g, '\\le')
-    .replace(/±/g, '\\pm')
-    .replace(/×/g, '\\times')
+    .replace(/[±]/g, '\\pm')
+    .replace(/[∓]/g, '\\mp')
+    .replace(/[×]/g, '\\times')
     .replace(/[÷／]/g, '\\div')
-    // マイナス記号のバリエーションを網羅 (長音、漢字の一、各種ダッシュ)
+    .replace(/[∞]/g, '\\infty')
+    .replace(/[∴]/g, '\\therefore')
+    .replace(/[∵]/g, '\\because')
+    .replace(/[∽]/g, '\\backsim')
+    .replace(/[∝]/g, '\\propto')
+    .replace(/[√]/g, '\\sqrt')
+    .replace(/[π]/g, '\\pi')
+    .replace(/[≡]/g, '\\equiv')
+    .replace(/[≒]/g, '\\approx')
+    .replace(/[＋+]/g, '+')
+    // マイナス記号のバリエーションを統一[cite: 8]
     .replace(/[－—–ー一⁻−]/g, '-') 
-    .replace(/√/g, '\\sqrt')
-    .replace(/π/g, '\\pi')
-    .replace(/≡/g, '\\equiv')
-    .replace(/≒/g, '\\approx')
-    .replace(/＋/g, '+')
     
-    // 不要な空白用コマンドの削除[cite: 8]
+    // 図形・集合記号等[cite: 8]
+    .replace(/[∠]/g, '\\angle')
+    .replace(/[⊥]/g, '\\perp')
+    .replace(/[△]/g, '\\triangle')
+    .replace(/[平行]/g, '\\parallel')
+    .replace(/[°]/g, '^{\\circ}')
+    .replace(/[∂]/g, '\\partial')
+    .replace(/[∫]/g, '\\int')
+    .replace(/[∑]/g, '\\sum')
+    
+    // 不要なレイアウト用コマンドの削除[cite: 8]
     .replace(/\\[,;:!]/g, '')
     .replace(/\\quad/g, '')
     .replace(/\\qquad/g, '');
 }
 
-// 日本語が混在した入力の$位置を標準化[cite: 8]
-function formatMixedTeX(input: string): string {
+/**
+ * 日本語混じりのテキストから数式部分を抽出して$で囲む[cite: 8]
+ */
+export function formatMixedTeX(input: string): string {
   if (!input) return "";
   const noDollar = input.replace(/\$/g, "");
-  // 半角文字ブロックを抽出して$で囲む
   return noDollar.replace(/[\x20-\x7E]+/g, (match) => {
     const trimmed = match.trim();
     if (!trimmed || /^[,]+$/.test(trimmed)) {
@@ -122,30 +160,29 @@ function formatMixedTeX(input: string): string {
   });
 }
 
-// 最終的なフォーマット処理
-function format(input: string): string {
+/**
+ * 表記揺れを吸収する総合フォーマット関数[cite: 8]
+ */
+export function format(input: string): string {
+  // 1. 全角を半角へ、記号を標準化[cite: 8]
   let str = zenkakuToHankaku(input);
   str = normalizeTeXCommand(str);
+  
+  // 2. 記号周りの空白を詰め、数式を一塊のブロックにする処理[cite: 8]
+  str = str.replace(/\s+/g, ' ');
+  str = str.replace(/\s?([=+\-*/^(),<>])\s?/g, '$1');
+
+  // 3. テキスト中の数式部分を$で囲む[cite: 8]
   str = formatMixedTeX(str);
 
+  // 4. 最終的な読みやすさ・比較用の微調整[cite: 3, 8]
   return trimSpace(
     str
-      // 1. 改行や全角スペースを半角スペースへ[cite: 3, 8]
       .replace(/\n/g, ' ')
-      .replace(/　/g, ' ')
-      // 2. 連続する空白を1つに集約
-      .replace(/\s+/g, ' ')
-      // 3. 演算子やカンマ周りの空白を詰める (表記揺れ吸収のため)
-      .replace(/\s?([,()=+-])\s?/g, '$1')
-      // 4. バックスラッシュの手前を半角空白1つにする[cite: 3, 8]
       .replace(/\s*(?<!\\)(?=\\)/g, ' ')
-      // 5. 英字と数字の間にスペースを追加[cite: 3, 8]
       .replace(/([a-z])([0-9])/g, '$1 $2')
-      // 6. 特定記号の前後にはスペースを入れる[cite: 3, 8]
       .replace(/([&|[\]{}])/g, ' $1 ')
-      // 7. 連続バックスラッシュ（\\）にスペースを追加[cite: 3, 8]
       .replace(/(\\\\)/g, ' $1 ')
-      // 8. 最後に再度空白の連続を1つに集約
       .replace(/\s\s+/g, ' ')
   );
 }

--- a/src/lib/judge.tsx
+++ b/src/lib/judge.tsx
@@ -16,6 +16,7 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
   let c_f = format(correct_answer_tex);
   let y_f = format(your_answer_tex);
 
+  // 1. 文字列としての完全一致判定[cite: 8]
   if (correct_answer_tex === your_answer_tex) {
     console.log("完全一致");
     return JudgeResult.Correct;
@@ -24,8 +25,9 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
     return JudgeResult.Correct;
   }
 
-  // 数学的な等価判定[cite: 3]
+  // 2. 数学的な等価判定 (Nerdamerを使用)[cite: 3, 8]
   try {
+    // $を取り除き、純粋な数式として評価
     let c_n = nerdamer.convertFromLaTeX(correct_answer_tex.replace(/\$/g, ''));
     let y_n = nerdamer.convertFromLaTeX(your_answer_tex.replace(/\$/g, ''));
 
@@ -38,6 +40,7 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
     }
   } catch (e) { }
 
+  // 3. フォーマット後の数式一致判定[cite: 3, 8]
   try {
     let c_f_n = nerdamer.convertFromLaTeX(c_f.replace(/\$/g, ''));
     let y_f_n = nerdamer.convertFromLaTeX(y_f.replace(/\$/g, ''));
@@ -51,58 +54,61 @@ export default function judge(correct_answer_tex: string, your_answer_tex: strin
   return JudgeResult.Unknown;
 }
 
+// 先頭と末尾の空白を削除[cite: 3, 8]
 function trimSpace(input: string): string {
-  // 先頭と末尾の空白を削除[cite: 3]
   return input.replace(/^\s+|\s+$/g, '');
 }
 
+// 全角文字を半角に、句読点をカンマ・ピリオドに変換
 function zenkakuToHankaku(str: string): string {
-  // 全角英数字を半角に変換、全角カンマを置換
   return str
+    // 英数字の変換[cite: 8]
     .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0))
-    .replace(/，/g, ',');
+    // 記号・括弧の変換
+    .replace(/[，、]/g, ',') // 全角カンマと読点
+    .replace(/[．。]/g, '.') // 全角ピリオドと句点
+    .replace(/（/g, '(')   // 丸括弧
+    .replace(/）/g, ')')
+    .replace(/［/g, '[')   // 角括弧
+    .replace(/］/g, ']')
+    .replace(/｛/g, '{')   // 中括弧
+    .replace(/｝/g, '}');
 }
 
-// 記号や特定のコマンドを標準的な形式に置換する関数
+// 記号やコマンドの標準化
 function normalizeTeXCommand(input: string): string {
   return input
-    // コマンドの標準化
+    // コマンドの標準化[cite: 8]
     .replace(/\\dfrac/g, '\\frac')
     .replace(/\\tfrac/g, '\\frac')
     .replace(/\\left/g, '')
     .replace(/\\right/g, '')
-    .replace(/\\geqq/g, '\\ge') // 日本語環境の不等号を標準へ
+    .replace(/\\geqq/g, '\\ge')
     .replace(/\\leqq/g, '\\le')
     
-    // Unicode記号をTeXコマンドへ置換
+    // Unicode記号をTeXに置換[cite: 8]
     .replace(/＝/g, '=')
     .replace(/≠/g, '\\ne')
     .replace(/[≧≥]/g, '\\ge')
     .replace(/[≦≤]/g, '\\le')
     .replace(/±/g, '\\pm')
-    .replace(/∓/g, '\\mp')
     .replace(/×/g, '\\times')
     .replace(/[÷／]/g, '\\div')
-    .replace(/∞/g, '\\infty')
-    .replace(/∴/g, '\\therefore')
-    .replace(/∵/g, '\\because')
-    .replace(/∽/g, '\\backsim')
-    .replace(/∝/g, '\\propto')
+    // マイナス記号のバリエーションを網羅 (長音、漢字の一、各種ダッシュ)
+    .replace(/[－—–ー一⁻−]/g, '-') 
     .replace(/√/g, '\\sqrt')
     .replace(/π/g, '\\pi')
     .replace(/≡/g, '\\equiv')
     .replace(/≒/g, '\\approx')
-    .replace(/（/g, '(')
-    .replace(/）/g, ')')
     .replace(/＋/g, '+')
-    .replace(/[－—–]/g, '-') // 各種ダッシュ・マイナス記号を統一
     
-    // 不要なレイアウト用コマンドの削除
+    // 不要な空白用コマンドの削除[cite: 8]
     .replace(/\\[,;:!]/g, '')
     .replace(/\\quad/g, '')
     .replace(/\\qquad/g, '');
 }
 
+// 日本語が混在した入力の$位置を標準化[cite: 8]
 function formatMixedTeX(input: string): string {
   if (!input) return "";
   const noDollar = input.replace(/\$/g, "");
@@ -116,27 +122,30 @@ function formatMixedTeX(input: string): string {
   });
 }
 
+// 最終的なフォーマット処理
 function format(input: string): string {
-  // 1. 全角を半角へ 2. 記号をTeXへ 3. $の位置を正規化
   let str = zenkakuToHankaku(input);
   str = normalizeTeXCommand(str);
   str = formatMixedTeX(str);
 
   return trimSpace(
     str
-      // バックスラッシュの手前を半角空白1つにする[cite: 3]
-      .replace(/\s*(?<!\\)(?=\\)/g, ' ')
-      // 英字と数字の間にスペースを追加[cite: 3]
-      .replace(/([a-z])([0-9])/g, '$1 $2')
-      // 改行をスペースへ[cite: 3]
+      // 1. 改行や全角スペースを半角スペースへ[cite: 3, 8]
       .replace(/\n/g, ' ')
-      // 全角スペースを半角スペースへ[cite: 3]
       .replace(/　/g, ' ')
-      // 特定記号の前後にスペースを追加[cite: 3]
-      .replace(/([&|()[\]{}])/g, ' $1 ')
-      // 連続バックスラッシュにスペースを追加[cite: 3]
+      // 2. 連続する空白を1つに集約
+      .replace(/\s+/g, ' ')
+      // 3. 演算子やカンマ周りの空白を詰める (表記揺れ吸収のため)
+      .replace(/\s?([,()=+-])\s?/g, '$1')
+      // 4. バックスラッシュの手前を半角空白1つにする[cite: 3, 8]
+      .replace(/\s*(?<!\\)(?=\\)/g, ' ')
+      // 5. 英字と数字の間にスペースを追加[cite: 3, 8]
+      .replace(/([a-z])([0-9])/g, '$1 $2')
+      // 6. 特定記号の前後にはスペースを入れる[cite: 3, 8]
+      .replace(/([&|[\]{}])/g, ' $1 ')
+      // 7. 連続バックスラッシュ（\\）にスペースを追加[cite: 3, 8]
       .replace(/(\\\\)/g, ' $1 ')
-      // 2つ以上の空白を1つに集約[cite: 3]
+      // 8. 最後に再度空白の連続を1つに集約
       .replace(/\s\s+/g, ' ')
   );
 }

--- a/src/lib/judge.tsx
+++ b/src/lib/judge.tsx
@@ -1,83 +1,142 @@
-//https://nerdamer.com/functions/nerdamer.convertFromLaTeX.html
-
 import nerdamer from 'nerdamer';
 
+// 判定結果の定義[cite: 3]
 enum JudgeResult {
-  Unknown,      //0
-  MabyCorrect,  //1
-  Correct,      //2
+  Unknown,
+  MabyCorrect,
+  Correct,
 }
 
 export default function judge(correct_answer_tex: string, your_answer_tex: string) {
-  // 文字列の先頭と最後のスペースを削除する
-  correct_answer_tex = trimSpace(correct_answer_tex)
-  your_answer_tex = trimSpace(your_answer_tex)
+  // 文字列の前後空白を削除[cite: 3]
+  correct_answer_tex = trimSpace(correct_answer_tex);
+  your_answer_tex = trimSpace(your_answer_tex);
 
-  // フォーマット
-  let c_f = format(correct_answer_tex)
-  let y_f = format(your_answer_tex)
+  // フォーマット処理の適用
+  let c_f = format(correct_answer_tex);
+  let y_f = format(your_answer_tex);
 
   if (correct_answer_tex === your_answer_tex) {
-    console.log("完全一致")
-    return JudgeResult.Correct
+    console.log("完全一致");
+    return JudgeResult.Correct;
   } else if (c_f === y_f) {
-    console.log("フォーマットすると一致")
-    return JudgeResult.Correct
+    console.log("フォーマットすると一致");
+    return JudgeResult.Correct;
   }
 
-  // 数式の比較
+  // 数学的な等価判定[cite: 3]
   try {
-    let c_n = nerdamer.convertFromLaTeX(correct_answer_tex)
-    let y_n = nerdamer.convertFromLaTeX(your_answer_tex)
+    let c_n = nerdamer.convertFromLaTeX(correct_answer_tex.replace(/\$/g, ''));
+    let y_n = nerdamer.convertFromLaTeX(your_answer_tex.replace(/\$/g, ''));
 
     if (nerdamer(c_n).eq(y_n)) {
-      console.log("数式が一致")
-      return JudgeResult.MabyCorrect
+      console.log("数式が一致");
+      return JudgeResult.MabyCorrect;
     } else if (c_n.toString() === y_n.toString()) {
-      console.log("数式の文字列が一致")
-      return JudgeResult.MabyCorrect
+      console.log("数式の文字列が一致");
+      return JudgeResult.MabyCorrect;
     }
   } catch (e) { }
 
-  // フォーマットして数式の比較
   try {
-    let c_f_n = nerdamer.convertFromLaTeX(c_f)
-    let y_f_n = nerdamer.convertFromLaTeX(y_f)
+    let c_f_n = nerdamer.convertFromLaTeX(c_f.replace(/\$/g, ''));
+    let y_f_n = nerdamer.convertFromLaTeX(y_f.replace(/\$/g, ''));
 
     if (nerdamer(c_f_n).eq(y_f_n)) {
-      console.log("フォーマットすると数式が一致")
-      return JudgeResult.MabyCorrect
+      console.log("フォーマットすると数式が一致");
+      return JudgeResult.MabyCorrect;
     }
   } catch (e) { }
 
-  return JudgeResult.Unknown
+  return JudgeResult.Unknown;
 }
 
-// 文字列の先頭と最後のスペースを削除する
 function trimSpace(input: string): string {
-  // ^ 先頭の \s スペース + 1文字以上 
-  // | または
-  // \s スペース + 1文字以上  $ 最後
-  // を削除する
+  // 先頭と末尾の空白を削除[cite: 3]
   return input.replace(/^\s+|\s+$/g, '');
 }
 
-function format(input: string): string {
-  return trimSpace( // 最初のスペースを削除
-    input
-      // もし \ の前が \ でなければ、\ の前にスペースを追加する
-      .replace(/(?<!\\)\\/g, ' \\')
-      // もし数字の前がアルファベットであれば、数字とアルファベットの間にスペースを追加する
-      .replace(/([a-z])([0-9])/g, '$1 $2')
-      // 改行をスペースに置き換える
-      .replace(/\n/g, ' ')
-      // 全角スペースを半角スペースに置き換える
-      .replace(/　/g, ' ')
-      // これらの記号の前後にスペースを追加する
-      .replace(/([&|(|)|[|\]|{|}])/g, ' $1 ')
-      .replace(/(\\\\)/g, ' $1 ')
-      // スペースが2つ以上連続していたら1つにする
-      .replace(/\s\s+/g, ' ')
-  )
+function zenkakuToHankaku(str: string): string {
+  // 全角英数字を半角に変換、全角カンマを置換
+  return str
+    .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0))
+    .replace(/，/g, ',');
 }
 
+// 記号や特定のコマンドを標準的な形式に置換する関数
+function normalizeTeXCommand(input: string): string {
+  return input
+    // コマンドの標準化
+    .replace(/\\dfrac/g, '\\frac')
+    .replace(/\\tfrac/g, '\\frac')
+    .replace(/\\left/g, '')
+    .replace(/\\right/g, '')
+    .replace(/\\geqq/g, '\\ge') // 日本語環境の不等号を標準へ
+    .replace(/\\leqq/g, '\\le')
+    
+    // Unicode記号をTeXコマンドへ置換
+    .replace(/＝/g, '=')
+    .replace(/≠/g, '\\ne')
+    .replace(/[≧≥]/g, '\\ge')
+    .replace(/[≦≤]/g, '\\le')
+    .replace(/±/g, '\\pm')
+    .replace(/∓/g, '\\mp')
+    .replace(/×/g, '\\times')
+    .replace(/[÷／]/g, '\\div')
+    .replace(/∞/g, '\\infty')
+    .replace(/∴/g, '\\therefore')
+    .replace(/∵/g, '\\because')
+    .replace(/∽/g, '\\backsim')
+    .replace(/∝/g, '\\propto')
+    .replace(/√/g, '\\sqrt')
+    .replace(/π/g, '\\pi')
+    .replace(/≡/g, '\\equiv')
+    .replace(/≒/g, '\\approx')
+    .replace(/（/g, '(')
+    .replace(/）/g, ')')
+    .replace(/＋/g, '+')
+    .replace(/[－—–]/g, '-') // 各種ダッシュ・マイナス記号を統一
+    
+    // 不要なレイアウト用コマンドの削除
+    .replace(/\\[,;:!]/g, '')
+    .replace(/\\quad/g, '')
+    .replace(/\\qquad/g, '');
+}
+
+function formatMixedTeX(input: string): string {
+  if (!input) return "";
+  const noDollar = input.replace(/\$/g, "");
+  // 半角文字ブロックを抽出して$で囲む
+  return noDollar.replace(/[\x20-\x7E]+/g, (match) => {
+    const trimmed = match.trim();
+    if (!trimmed || /^[,]+$/.test(trimmed)) {
+      return match;
+    }
+    return match.replace(trimmed, () => `$${trimmed}$`);
+  });
+}
+
+function format(input: string): string {
+  // 1. 全角を半角へ 2. 記号をTeXへ 3. $の位置を正規化
+  let str = zenkakuToHankaku(input);
+  str = normalizeTeXCommand(str);
+  str = formatMixedTeX(str);
+
+  return trimSpace(
+    str
+      // バックスラッシュの手前を半角空白1つにする[cite: 3]
+      .replace(/\s*(?<!\\)(?=\\)/g, ' ')
+      // 英字と数字の間にスペースを追加[cite: 3]
+      .replace(/([a-z])([0-9])/g, '$1 $2')
+      // 改行をスペースへ[cite: 3]
+      .replace(/\n/g, ' ')
+      // 全角スペースを半角スペースへ[cite: 3]
+      .replace(/　/g, ' ')
+      // 特定記号の前後にスペースを追加[cite: 3]
+      .replace(/([&|()[\]{}])/g, ' $1 ')
+      // 連続バックスラッシュにスペースを追加[cite: 3]
+      .replace(/(\\\\)/g, ' $1 ')
+      // 2つ以上の空白を1つに集約[cite: 3]
+      .replace(/\s\s+/g, ' ')
+  );
+}

--- a/src/msg-ja.ts
+++ b/src/msg-ja.ts
@@ -280,7 +280,7 @@ export const msg = {
     "LATE_PREFIX": "期限から ",
     "LATE_SUFFIX": "遅れ",
     "LESS_THAN_A_MINUTE": "1分未満",
-    "RAW_TEX": "Raw TeX",
+    "RAW_TEX": "原文TeX",
     "CLOSE": "閉じる",
     "ANSWER_LABEL": "解答",
     "SCORE_LABEL": "得点",
@@ -291,4 +291,5 @@ export const msg = {
     "AUTO_GRADING_CONFIRM_TITLE": "自動採点の実行",
     "AUTO_GRADING_CONFIRM_MESSAGE": "自動採点を実行すると、現在入力されている点数が上書きされます。よろしいですか？",
     "EXECUTE": "実行",
+    "FORMATED_TEX": "フォーマットされたTeX",
 }

--- a/src/msg-ja.ts
+++ b/src/msg-ja.ts
@@ -287,4 +287,8 @@ export const msg = {
     "MOVE_UP": "上へ",
     "MOVE_DOWN": "下へ",
     "DUPLICATE": "コピーを作成",
+    "AUTO_GRADING": "自動採点",
+    "AUTO_GRADING_CONFIRM_TITLE": "自動採点の実行",
+    "AUTO_GRADING_CONFIRM_MESSAGE": "自動採点を実行すると、現在入力されている点数が上書きされます。よろしいですか？",
+    "EXECUTE": "実行",
 }


### PR DESCRIPTION
回答画面で数式入力のキーボードを、入力中の数式のみに表示するようにした。

自動採点の強化
空白や全角・半角の違いを吸収した。
記号文字として入力できてしまう数学記号をTeX書式に置換するようにした。

<img width="651" height="326" alt="image" src="https://github.com/user-attachments/assets/345d73b5-28f0-4429-9d93-c327ea32beda" />
<img width="733" height="383" alt="image" src="https://github.com/user-attachments/assets/cfc84824-72b8-4ebc-b762-93ac080cf44b" />
同一の数式として判定できる例